### PR TITLE
dont check power if oob missing

### DIFF
--- a/socrates_gui/static/js/assets.js
+++ b/socrates_gui/static/js/assets.js
@@ -39,7 +39,7 @@ export class AssetView extends React.Component {
             this.setState({key: key});
     }
     componentDidMount() {
-        if (typeof this.asset !== "undefined")
+        if (typeof this.asset !== "undefined" && this.asset.hasOwnProperty('oob'))
             fetchAPI({url: "/asset/" + encodeURIComponent(this.asset.id) + "/ipmi/"})
               .then((power) => this.setState({power: power ? power['power_state'] : "Unknown"}));
     }


### PR DESCRIPTION
Check that assets have out of band property.
This avoids generating failed ipmi_power_state tasks whenever such an asset without OOB info is accessed via the gui.
Is this a clever way of doing it?